### PR TITLE
fix: typos across top-level pages

### DIFF
--- a/build/cv/index.html
+++ b/build/cv/index.html
@@ -286,7 +286,7 @@
 
 <hr />
 <h5 id="university-of-alaska-anchorage-anchorage-alaska">university of alaska anchorage, anchorage, alaska</h5>
-<p>– <em>student/athelete</em> (1992-1994)</p>
+<p>– <em>student/athlete</em> (1992-1994)</p>
 
 <ul>
   <li>studied biochemistry and competed in d1 nordic skiing</li>
@@ -294,7 +294,7 @@
 
 <hr />
 <h5 id="university-of-colorado-at-boulder-boulder-colorado">university of colorado at boulder, boulder, colorado</h5>
-<p>– <em>student/athelete</em> (1999-2003)</p>
+<p>– <em>student/athlete</em> (1999-2003)</p>
 
 <ul>
   <li>studied computer science and designed a senior year project for noaa/cires</li>

--- a/build/index.html
+++ b/build/index.html
@@ -176,7 +176,7 @@
   <p><em>otherwise</em></p>
 </blockquote>
 
-<p><strong>welcome to my</strong> 🛖️, please make yourself at ome.</p>
+<p><strong>welcome to my</strong> 🛖️, please make yourself at home.</p>
 
 <p>here, you will find a <a href="/nerd">lotta code</a>, a little <a href="/about">narcissism</a>.</p>
 

--- a/build/now/index.html
+++ b/build/now/index.html
@@ -180,12 +180,12 @@ lotta PT but, <a href="https://photos.app.goo.gl/ZLLWKpux5jns3JUH9">mountains</a
 soon…</p>
   </li>
   <li>
-    <p>doing tons of OSS attm.  <a href="https://github.com/ahoward" target="_blank">https://github.com/ahoward</a></p>
+    <p>doing tons of OSS atm.  <a href="https://github.com/ahoward" target="_blank">https://github.com/ahoward</a></p>
   </li>
   <li>
-    <p>quietly steathing the new steath agency which is
+    <p>quietly stealthing the new stealth agency which is
 <a href="https://mountainhigh.codes">stealthy</a>.  RN we aren’t taking clients, just
-building shit fromm a bus in Alaska.  like
+building shit from a bus in Alaska.  like
 <a href="https://photos.app.goo.gl/U1HHzcNkjV4GDurq5">actually</a>.  skiing is great too.</p>
   </li>
   <li>

--- a/build/ro/pages/cv/body.md
+++ b/build/ro/pages/cv/body.md
@@ -109,14 +109,14 @@ i am currently in a unique position, having reduced my own life footprint dramat
 
 -----------------------------
 ##### university of alaska anchorage, anchorage, alaska
--- _student/athelete_ (1992-1994)
+-- _student/athlete_ (1992-1994)
 
 * studied biochemistry and competed in d1 nordic skiing
 
 
 -----------------------------
 ##### university of colorado at boulder, boulder, colorado
--- _student/athelete_ (1999-2003)
+-- _student/athlete_ (1999-2003)
 
 * studied computer science and designed a senior year project for noaa/cires
 * earned a 10th place finish at collegiate nationals and transitioned into the workplace at noaa/cires as a research associate

--- a/build/ro/pages/index/body.md
+++ b/build/ro/pages/index/body.md
@@ -6,7 +6,7 @@ see what i am doing 👉 [now](/now) 👈
 
 > _otherwise_
 
- **welcome to my** 🛖️, please make yourself at ome.
+ **welcome to my** 🛖️, please make yourself at home.
 
 here, you will find a [lotta code](/nerd), a little [narcissism](/about).
 

--- a/build/ro/pages/now/body.md
+++ b/build/ro/pages/now/body.md
@@ -9,11 +9,11 @@
   lotta PT but, [mountains](https://photos.app.goo.gl/ZLLWKpux5jns3JUH9)
   soon...
 
-- doing tons of OSS attm.  https://github.com/ahoward
+- doing tons of OSS atm.  https://github.com/ahoward
 
-- quietly steathing the new steath agency which is
+- quietly stealthing the new stealth agency which is
   [stealthy](https://mountainhigh.codes).  RN we aren't taking clients, just
-  building shit fromm a bus in Alaska.  like
+  building shit from a bus in Alaska.  like
   [actually](https://photos.app.goo.gl/U1HHzcNkjV4GDurq5).  skiing is great too.
 
 - married [jess](/jess) ❤️

--- a/public/ro/pages/cv/body.md
+++ b/public/ro/pages/cv/body.md
@@ -109,14 +109,14 @@ i am currently in a unique position, having reduced my own life footprint dramat
 
 -----------------------------
 ##### university of alaska anchorage, anchorage, alaska
--- _student/athelete_ (1992-1994)
+-- _student/athlete_ (1992-1994)
 
 * studied biochemistry and competed in d1 nordic skiing
 
 
 -----------------------------
 ##### university of colorado at boulder, boulder, colorado
--- _student/athelete_ (1999-2003)
+-- _student/athlete_ (1999-2003)
 
 * studied computer science and designed a senior year project for noaa/cires
 * earned a 10th place finish at collegiate nationals and transitioned into the workplace at noaa/cires as a research associate

--- a/public/ro/pages/index/body.md
+++ b/public/ro/pages/index/body.md
@@ -6,7 +6,7 @@ see what i am doing 👉 [now](/now) 👈
 
 > _otherwise_
 
- **welcome to my** 🛖️, please make yourself at ome.
+ **welcome to my** 🛖️, please make yourself at home.
 
 here, you will find a [lotta code](/nerd), a little [narcissism](/about).
 

--- a/public/ro/pages/now/body.md
+++ b/public/ro/pages/now/body.md
@@ -9,11 +9,11 @@
   lotta PT but, [mountains](https://photos.app.goo.gl/ZLLWKpux5jns3JUH9)
   soon...
 
-- doing tons of OSS attm.  https://github.com/ahoward
+- doing tons of OSS atm.  https://github.com/ahoward
 
-- quietly steathing the new steath agency which is
+- quietly stealthing the new stealth agency which is
   [stealthy](https://mountainhigh.codes).  RN we aren't taking clients, just
-  building shit fromm a bus in Alaska.  like
+  building shit from a bus in Alaska.  like
   [actually](https://photos.app.goo.gl/U1HHzcNkjV4GDurq5).  skiing is great too.
 
 - married [jess](/jess) ❤️


### PR DESCRIPTION
## Summary
- Fixed "ome" → "home" on index page
- Fixed "athelete" → "athlete" on cv page (2 occurrences)
- Fixed "attm" → "atm" on now page
- Fixed "steathing" → "stealthing" on now page
- Fixed "steath" → "stealth" on now page
- Fixed "fromm" → "from" on now page

🤖 Generated with [Claude Code](https://claude.com/claude-code)